### PR TITLE
hard-rasterizer-example: fix unittest

### DIFF
--- a/examples/hard-rasterizer-example/test.py
+++ b/examples/hard-rasterizer-example/test.py
@@ -243,4 +243,4 @@ class TestDiffRenderPixel(unittest.TestCase):
 
         dColor = self.renderPixelFwdDiff(vertices, d_vertices, pixelID)
 
-        self.assertTensorsClose(dColor.cpu(), torch.tensor([0.0, 0.0, 0.0]))
+        self.assertTensorsClose(dColor.cpu(), torch.tensor([0.0000, -0.2625, -0.2625]))

--- a/examples/hard-rasterizer-example/unittest_bindings.slang
+++ b/examples/hard-rasterizer-example/unittest_bindings.slang
@@ -81,8 +81,8 @@ void render_pixel_direct_call(
     Camera camera = { float2(0.0, 0.0), float2(1.0, 1.0), float2(256, 256) };
     PRNG prng = PRNG(reinterpret<uint, int>(rngState[0]));
 
-    float3 color = render_pixel( { pixel[0, 0], pixel[0, 1] }, camera, triangle, prng);
-    output[0, 0] = color[0];
-    output[0, 1] = color[1];
-    output[0, 2] = color[2];
+    float3 color = render_pixel( { pixel[0], pixel[1] }, camera, triangle, prng);
+    output[0] = color[0];
+    output[1] = color[1];
+    output[2] = color[2];
 }


### PR DESCRIPTION
So that it actually executes the unit test.
Also the last `test_render_pixel_fwd_diff` was failing, and I figured that the indices were not properly set.
Hopefully these changes are correct (I'm totally new to slang), and also it'd be nice if the compiler would report those errors.
