### PR TITLE
Inline MLP example: Fix issue with CUDA arch versions on Docker containers

### DIFF
--- a/examples/hard-rasterizer-example/test.py
+++ b/examples/hard-rasterizer-example/test.py
@@ -208,7 +208,7 @@ class TestTriangle(unittest.TestCase):
 class TestDiffRenderPixel(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.rasterizer2d = slangpy.loadModule("unittest_bindings.slang", verbose=True)
+        self.rasterizer2d = slangpy.loadModule("unittest_bindings.slang")
 
     def assertTensorsEqual(self, a, b, msg=None):
         self.assertTrue(torch.all(torch.eq(a, b)), msg = f"Tensors not close: {a} != {b}")

--- a/examples/inline-mlp-example/image_model.py
+++ b/examples/inline-mlp-example/image_model.py
@@ -1,7 +1,20 @@
 import slangpy
 import torch
+import os
 
 launchBlockSize = (32, 8, 1)
+
+# Before loading our module, we're going to pre-process the TORCH_CUDA_ARCH_LIST tag from the environment. 
+# This is to get around a bug with how torch constructs arch flags: explicitly providing arch flags seems to
+# not override torch's default arch flags and cause compiler errors due to setting the SM version too low.
+# 
+# We therefore replace the env list with a restricted list of arches that we know will work.
+#
+if "TORCH_CUDA_ARCH_LIST" in os.environ:
+    # Go through space-separated list of arches and remove any that are below 8.0
+    arches = os.environ["TORCH_CUDA_ARCH_LIST"].split(" ")
+    arches = [arch for arch in arches if not int(arch.split(".")[0]) <= 7]
+    os.environ["TORCH_CUDA_ARCH_LIST"] = " ".join(arches)
 
 m = slangpy.loadModule('image-model.slang', 
                        defines={


### PR DESCRIPTION
Removes unsupported versions from `TORCH_CUDA_ARCH_LIST` environment variable, if present. 

Ideally, we would simply specify the supported versions as `extra_cflags` when creating the torch extension, but there appears to be a bug with doing this, so we use a workaround for now.